### PR TITLE
don't try to use a stooper unless you have a stooper

### DIFF
--- a/RELEASE/scripts/CONSUME.ash
+++ b/RELEASE/scripts/CONSUME.ash
@@ -777,7 +777,7 @@ void handle_organ_expanders(Diet d, OrganSpace space, OrganSpace max, boolean ni
 	d.handle_stomache_expander(space, max, $item[cuppa Voraci tea], 1);
 	d.handle_stomache_expander(space, max, $item[sweet tooth], 1);
 	d.handle_stomache_expander(space, max, $item[lupine appetite hormones], 3);
-	if(nightcap && my_familiar() != $familiar[stooper])
+	if(nightcap && have_familiar($familiar[stooper]) && my_familiar() != $familiar[stooper])
 	{
 		DietAction useStooper;
 		useStooper.organ = ORGAN_STOOPER;


### PR DESCRIPTION
This was throwing an error on one of my multis without a stooper. 

Testable by running CONSUME NIGHTCAP on a character without a stooper. Without this patch, script errors with "You don't have a stooper for a familiar." With this patch, the script completes successfully.