### PR TITLE
Fixed bug when CONSUME ORGANS presents non-maximum spleen use

### DIFF
--- a/RELEASE/scripts/CONSUME.ash
+++ b/RELEASE/scripts/CONSUME.ash
@@ -968,14 +968,28 @@ Diet get_diet(OrganSpace space, OrganSpace max, boolean nightcap)
 	{
 		for(int i = d.actions.count() - 1; i >= 0; --i)
 		{
-			if(d.actions[i].organ == ORGAN_SPLEEN && d.actions[i].space <= spleen_buffer)
+			if(d.actions[i].organ == ORGAN_SPLEEN)
 			{
-				spleen_buffer -= d.actions[i].space;				
-				d.remove_action(i);
-			}
-			if (spleen_buffer <= 0) {
-				break;
-			}
+				if (d.actions[i].space <= spleen_buffer) 
+				{
+					spleen_buffer -= d.actions[i].space;					
+					d.remove_action(i);
+				} 
+				else 
+				{
+					int spaceToFill = d.actions[i].space - spleen_buffer;					
+					spleen_buffer = 0;
+					d.remove_action(i);
+					while(spaceToFill > 0)
+					{
+						Consumable filler = d.best_spleen(spaceToFill);
+						spaceToFill -= filler.space;
+						d.insert_action(filler.to_action(d), i);
+						++i;
+					}
+				}
+			}						
+			if (spleen_buffer <= 0) break;			
 		}
 	}
 	


### PR DESCRIPTION
When spleen usage is not capped to the spleen limit (e.g. CONSUME SIM ORGANS 10 10 0 NOMEAT), it could previously end up with 10/10/15 spleen usage due to a bug where the diet attempts to "fill" the spleen cleansed by Sliders or Pickle Juices (even though the spleen usage was 0 and nothing was cleansed)

This fix adds a buffer to the spleen so that if any cleansers are consumed, there would actually be spleen to be cleansed. Any buffered spleen use is then removed from the end of the diet so that we do not consume past the user-defined limit after cleansing.