### PR TITLE
use git install instead of svn install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CONSUME.ash is a script that will handle your diet in Kingdom of Loathing for yo
 
 Run this command in the graphical CLI:
 <pre>
-svn checkout https://github.com/soolar/CONSUME.ash/trunk/RELEASE/
+git checkout https://github.com/soolar/CONSUME.ash.git
 </pre>
 Will require [a recent build of KoLMafia](http://builds.kolmafia.us/job/Kolmafia/lastSuccessfulBuild/).
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,3 @@
+{
+    "root_directory": "./RELEASE/"
+}


### PR DESCRIPTION
adds a manifest file & new install instructions for installing via mafia's built in git. Which works around some bugs that exist in github.com when checking out a git repo using svn