### PR TITLE
Handle Cookbookbat consumables

### DIFF
--- a/RELEASE/scripts/CONSUME.ash
+++ b/RELEASE/scripts/CONSUME.ash
@@ -217,7 +217,7 @@ void evaluate_consumables()
 	}
 	foreach it in $items[]
 	{
-		if(it.tradeable.to_boolean() == false || it == $item[Jeppson\'s Malort])
+		if(it.can_acquire() == false || it == $item[Jeppson\'s Malort])
 			continue;
 
 		if(it.levelreq > my_level())

--- a/RELEASE/scripts/CONSUME/INFO.ash
+++ b/RELEASE/scripts/CONSUME/INFO.ash
@@ -99,6 +99,11 @@ int daily_limit(item it)
 		// Universal Seasoning
 		case $item[Universal Seasoning]:
 			return item_amount($item[Universal Seasoning]) - get_property("_universalSeasoningsUsed").to_int();
+		// Cookbookbat legendary consumables. These are once per ascension but we handle that in can_acquire() on subsequent days.
+		case $item[Calzone of Legend]:
+		case $item[Deep Dish of Legend]:
+		case $item[Pizza of Legend]:
+			return 1;
 		// TODO: MOOOOOOOOOOOOOORE
 		default: return -1;
 	}
@@ -215,3 +220,33 @@ boolean has_unwanted_text_effect(item it)
 	return it.string_modifier("Effect").to_effect().is_unwanted_text_effect();
 }
 
+boolean can_acquire(item it)
+{
+	if ($items[baked veggie ricotta casserole,
+	plain calzone,
+	roasted vegetable focaccia,
+	ratatouille de Jarlsberg,
+	Jarlsberg's vegetable soup,
+	roasted vegetable of Jarlsberg,
+	St. Pete's sneaky smoothie,
+	Pete's wiley whey bar,
+	Pete's rich ricotta,
+	Boris's beer,
+	honey bun of Boris,
+	Boris's bread] contains it) {
+		// these are all untradable Cookbookbat consumables which can be crafted from tradeable ingredients
+		return true;
+	}
+	// these are consumable once per ascension and are tracked in appropriate mafia properties.
+	if (it == $item[Calzone of Legend] && !get_property("calzoneOfLegendEaten").to_boolean()) {
+		return true;
+	}
+	if (it == $item[Deep Dish of Legend] && !get_property("deepDishOfLegendEaten").to_boolean()) {
+		return true;
+	}
+	if (it == $item[Pizza of Legend] && !get_property("pizzaOfLegendEaten").to_boolean()) {
+		return true;
+	}
+	// for everything, just return use the tradeable record as before.
+	return it.tradeable.to_boolean();
+}

--- a/RELEASE/scripts/CONSUME/INFO.ash
+++ b/RELEASE/scripts/CONSUME/INFO.ash
@@ -99,11 +99,6 @@ int daily_limit(item it)
 		// Universal Seasoning
 		case $item[Universal Seasoning]:
 			return item_amount($item[Universal Seasoning]) - get_property("_universalSeasoningsUsed").to_int();
-		// Cookbookbat legendary consumables. These are once per ascension but we handle that in can_acquire() on subsequent days.
-		case $item[Calzone of Legend]:
-		case $item[Deep Dish of Legend]:
-		case $item[Pizza of Legend]:
-			return 1;
 		// TODO: MOOOOOOOOOOOOOORE
 		default: return -1;
 	}
@@ -235,16 +230,6 @@ boolean can_acquire(item it)
 	honey bun of Boris,
 	Boris's bread] contains it) {
 		// these are all untradable Cookbookbat consumables which can be crafted from tradeable ingredients
-		return true;
-	}
-	// these are consumable once per ascension and are tracked in appropriate mafia properties.
-	if (it == $item[Calzone of Legend] && !get_property("calzoneOfLegendEaten").to_boolean()) {
-		return true;
-	}
-	if (it == $item[Deep Dish of Legend] && !get_property("deepDishOfLegendEaten").to_boolean()) {
-		return true;
-	}
-	if (it == $item[Pizza of Legend] && !get_property("pizzaOfLegendEaten").to_boolean()) {
 		return true;
 	}
 	// for everything, just return use the tradeable record as before.


### PR DESCRIPTION
Cookbookbat consumables aren't tradable but are freely craftable from fully tradable ingredients.

Someone could get into a situation where they haven't learned the required recipe yet and CONSUME tries to acquire something but personally I think if `acquire` doesn't handle that gracefully, it's a mafia issue not a CONSUME issue (and I can't test that as all the accounts I have access to have used the recipes already).

Some example outputs (accounts are all overdrunk so not 100% representative as I have to use the ORGANS option to simulate).

```
> CONSUME SIM ORGANS 15 15 15 NOMEAT VALUE 4000

Your ideal diet: acquire 3 agua de vida; acquire 3 transdermal smoke patch; acquire 15 elemental caipiroska; acquire 1 roasted vegetable of Jarlsberg; acquire 7 baked veggie ricotta casserole; cast 2 The Ode to Booze; chew 3 agua de vida; chew 3 transdermal smoke patch; eat 7 baked veggie ricotta casserole; eat roasted vegetable of Jarlsberg; drink 15 elemental caipiroska;
This should cost roughly 37,200 meat
Adventure yield should be roughly 237-301
That's an average profit of 1,038,800
Including adventures you already have, you should profit 1,038,800 today
In total, you're filling up 15 fullness, 15 liver, and 15 spleen
```
baked veggie ricotta casserole is 8 advs/full so it beats almost everything at realistic VoA's.

Setting the legend foods tracking properties to false gives us
```
> CONSUME SIM ORGANS 16 21 18 NOMEAT VALUE 5000

Your ideal diet: acquire 18 transdermal smoke patch; acquire 21 Eye and a Twist; acquire 5 baked veggie ricotta casserole; acquire 1 Pizza of Legend; acquire 1 Calzone of Legend; acquire 1 Deep Dish of Legend; checkpoint; cast 3 The Ode to Booze; equip tuxedo shirt; chew 18 transdermal smoke patch; eat Pizza of Legend; eat Calzone of Legend; eat Deep Dish of Legend; eat 5 baked veggie ricotta casserole; drink 21 Eye and a Twist; familiar Cookbookbat; outfit checkpoint;
This should cost roughly 279,500 meat
Adventure yield should be roughly 328-431
That's an average profit of 1,617,711
Including adventures you already have, you should profit 1,617,711 today
In total, you're filling up 16 fullness, 21 liver, and 18 spleen
```
