### PR TITLE
add using whet stones

### DIFF
--- a/RELEASE/scripts/CONSUME.ash
+++ b/RELEASE/scripts/CONSUME.ash
@@ -1,6 +1,6 @@
 script "Capitalistic Optimal Noms Script (Ultra Mega Edition)";
 notify "soolar the second";
-since r20606; // Universal Seasoning tracking
+since r27060; // rock garden items 
 
 import <CONSUME/INFO.ash>
 import <CONSUME/CONSTANTS.ash>
@@ -64,6 +64,9 @@ Range get_adventures(DietAction da)
 			advs.min += 1;
 			if(advs.min >= advs.max)
 				advs.max += 1;
+			break;
+		case $item[whet stone]:
+			advs.add(1);
 			break;
 		}
 	}
@@ -154,6 +157,8 @@ void evaluate_consumable(Consumable c)
 		boolean smallRange = advs.max - advs.min <= 1;
 		if(item_price($item[special seasoning]) < (smallRange ? 1 : 0.5) * ADV_VALUE)
 			c.useSeasoning = true;
+		if(item_price($item[whet stone]) < ADV_VALUE)
+			c.useWhetStone = true;
 	}
 
 	record OrganMatcher
@@ -188,6 +193,7 @@ void evaluate_consumables()
 		frosty's frosty mug,
 		ol' scratch's salad fork,
 		Special Seasoning,
+		whet stone,
 		mojo filter,
 		spice melange,
 		fudge spork,
@@ -338,6 +344,8 @@ void evaluate_consumables()
 			}
 			if(c.useSeasoning)
 				b.append(" (w/seasoning)");
+			if(c.useWhetStone)
+				b.append(" (w/whet stone)");
 			b.append(" (");
 			b.append(c.get_value(d) / c.space);
 			b.append(")");

--- a/RELEASE/scripts/CONSUME/HELPERS.ash
+++ b/RELEASE/scripts/CONSUME/HELPERS.ash
@@ -144,6 +144,7 @@ int get_tool_organ(item tool)
 		case $item[Frosty's frosty mug]:
 			return ORGAN_LIVER;
 		case $item[Universal Seasoning]:
+		case $item[whet stone]:
 			return ORGAN_NONE;
 		default:
 			return ORGAN_ERROR;

--- a/RELEASE/scripts/CONSUME/RECORDS.ash
+++ b/RELEASE/scripts/CONSUME/RECORDS.ash
@@ -82,6 +82,7 @@ record Consumable
 	boolean useSporkIfPossible;
 	item bestMayo;
 	boolean useSeasoning;
+	boolean useWhetStone;
 };
 
 boolean is_nothing(Consumable c)
@@ -169,6 +170,8 @@ DietAction to_action(Consumable c, Diet d)
 	// figure out the tool(s)
 	if(c.useSeasoning)
 		da.tools[da.tools.count()] = $item[special seasoning];
+	if(c.useWhetStone)
+		da.tools[da.tools.count()] = $item[whet stone];
 	if(c.useForkMug)
 		da.tools[da.tools.count()] = c.get_fork_mug();
 	if(c.useSporkIfPossible && d.within_limit($item[fudge spork]))


### PR DESCRIPTION
`Your ideal diet: acquire 3 mojo filter; acquire 2 chocolate seal-clubbing club; acquire 1 essential tofu; acquire 18 transdermal smoke patch; acquire 21 Eye and a Twist; acquire 8 baked veggie ricotta casserole; acquire 8 whet stone; checkpoint; equip tuxedo shirt; drink Eye and a Twist; chew 15 transdermal smoke patch; use 8 whet stone; eat 8 baked veggie ricotta casserole; drink 20 Eye and a Twist; use 3 mojo filter; use essential tofu; chew 3 transdermal smoke patch; use 2 chocolate seal-clubbing club; familiar Cookbookbat; outfit checkpoint;`

Seems to work fine when I tested it. They add +1 to foods and are 'used' & uses can be stacked up & will be decremented by the game (and the mafia tracking property `whetStonesUsed`).
Could also check for pre-consumed whet stones by checking the property and only using any extra but that's a problem for future Malibu or future soolar.

P.S. I HATE YOU JIMMYKING.