### PR TITLE
Use batfellow prefs to track if we can consume batfellow consumables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ is what you would want to do if you are farming barf mountain and have the songb
 * Ultra Mega Sour Ball
 * Sweet Synthesis (optional)
 * Mayoflex
+* Frosty's Frosty Mug
+* Ol' Scratch's Salad Fork
+* Fudge Spork
 * Special Seasoning
 * Milk of Magnesium
 * The Ode to Booze
@@ -57,8 +60,12 @@ is what you would want to do if you are farming barf mountain and have the songb
 * cuppa Sobrie tea
 * sweet tooth
 * lupine appetite hormones
+* Universal Seasoning
+* Meteorite Ade
+* Jerks' Health&trade; Magazine
 * synthetic dog hair pill (from Map to Safety Shelter Grimace Prime)
 * distention pill (from Map to Safety Shelter Grimace Prime)
+* Drip consumables (nugget/wine/caviar/plum(?)/pilsner)
 * whet stone
 * Sweat Out Some Booze (from designer sweatpants)
 * Aug. 16th: Roller Coaster Day! (from august scepter)

--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ is what you would want to do if you are farming barf mountain and have the songb
 * Ultra Mega Sour Ball
 * Sweet Synthesis (optional)
 * Mayoflex
-* Frosty's Frosty Mug
-* Ol' Scratch's Salad Fork
-* Fudge Spork
 * Special Seasoning
 * Milk of Magnesium
 * The Ode to Booze
@@ -60,12 +57,8 @@ is what you would want to do if you are farming barf mountain and have the songb
 * cuppa Sobrie tea
 * sweet tooth
 * lupine appetite hormones
-* Universal Seasoning
-* Meteorite Ade
-* Jerks' Health&trade; Magazine
 * synthetic dog hair pill (from Map to Safety Shelter Grimace Prime)
 * distention pill (from Map to Safety Shelter Grimace Prime)
-* Drip consumables (nugget/wine/caviar/plum(?)/pilsner)
 * whet stone
 * Sweat Out Some Booze (from designer sweatpants)
 * Aug. 16th: Roller Coaster Day! (from august scepter)

--- a/RELEASE/scripts/CONSUME.ash
+++ b/RELEASE/scripts/CONSUME.ash
@@ -10,7 +10,6 @@ import <CONSUME/HELPERS.ash>
 static boolean haveSearched = false;
 boolean havePinkyRing = available_amount($item[mafia pinky ring]) > 0;
 boolean haveTuxedoShirt = available_amount($item[tuxedo shirt]) > 0;
-int mojoFiltersUseable = daily_limit($item[mojo filter]);
 int songDuration = my_accordion_buff_duration();
 
 boolean firstPassComplete = false;
@@ -509,10 +508,10 @@ void fill_liver(Diet d, OrganSpace space, OrganSpace max)
 
 void handle_special_items(Diet d, OrganSpace space, OrganSpace max)
 {
-	if(mojoFiltersUseable > 0)
+	if(d.within_limit($item[mojo filter]))
 	{
-		float mojoValue = spleen_value(mojoFiltersUseable) / mojoFiltersUseable -
-			item_price($item[mojo filter]);
+		int mojoFiltersUseable = daily_limit($item[mojo filter]);
+		float mojoValue = (spleen_value(mojoFiltersUseable) / mojoFiltersUseable) -	item_price($item[mojo filter]);
 		if(mojoValue > 0)
 		{
 			Consumable mojoFilter;

--- a/RELEASE/scripts/CONSUME.ash
+++ b/RELEASE/scripts/CONSUME.ash
@@ -1,6 +1,6 @@
 script "Capitalistic Optimal Noms Script (Ultra Mega Edition)";
 notify "soolar the second";
-since r27775; // Hobopolis consumables all 1/day
+since r27682; // Add Preference for Extra Time
 
 import <CONSUME/INFO.ash>
 import <CONSUME/CONSTANTS.ash>
@@ -10,6 +10,7 @@ import <CONSUME/HELPERS.ash>
 static boolean haveSearched = false;
 boolean havePinkyRing = available_amount($item[mafia pinky ring]) > 0;
 boolean haveTuxedoShirt = available_amount($item[tuxedo shirt]) > 0;
+int mojoFiltersUseable = daily_limit($item[mojo filter]);
 int songDuration = my_accordion_buff_duration();
 
 boolean firstPassComplete = false;
@@ -224,7 +225,7 @@ void evaluate_consumables()
 	}
 	foreach it in $items[]
 	{
-		if(it.can_acquire() == false)
+		if(it.can_acquire() == false || it == $item[Jeppson\'s Malort])
 			continue;
 
 		if(it.levelreq > my_level())
@@ -508,10 +509,10 @@ void fill_liver(Diet d, OrganSpace space, OrganSpace max)
 
 void handle_special_items(Diet d, OrganSpace space, OrganSpace max)
 {
-	if(d.within_limit($item[mojo filter]))
+	if(mojoFiltersUseable > 0)
 	{
-		int mojoFiltersUseable = daily_limit($item[mojo filter]);
-		float mojoValue = (spleen_value(mojoFiltersUseable) / mojoFiltersUseable) -	item_price($item[mojo filter]);
+		float mojoValue = spleen_value(mojoFiltersUseable) / mojoFiltersUseable -
+			item_price($item[mojo filter]);
 		if(mojoValue > 0)
 		{
 			Consumable mojoFilter;
@@ -1251,11 +1252,6 @@ void main(string command)
 	int spleen = spleen_limit() - my_spleen_use();
 	int spleenLimit = spleen_limit();
 
-	if(get_property("CONSUME.ALLOWLIFETIMELIMITED").to_boolean())
-	{
-		allow_lifetime_limited();
-	}
-
 	string [int] commands = command.split_string("\\s+");
 
 	for(int i = 0; i < commands.count(); ++i)
@@ -1333,15 +1329,11 @@ void main(string command)
 			case "REFRESH":
 				haveSearched = false;
 				break;
-			case "ALLOWLIFETIMELIMITED":
-				allow_lifetime_limited();
-				break;
 			case "HELP":
 				print("CONSUME.ash Commands:", "blue");
 				print("ALL - Fill all organs, for real.");
 				print("SIM - Present a diet that would fill you up, but don't execute it.");
 				print("NIGHTCAP - Fill all organs and then overdrink. Can be combined with SIM.");
-				print("ALLOWLIFETIMELIMITED - Allows once/life items like legend pizzas.");
 				print("ORGANS X Y Z - Set the amount of each organ to fill. X Y and " +
 					"Z should be numbers corresponding to stomache, liver, and spleen " +
 					"respectively. Note that if you set these above your max, CONSUME " +
@@ -1371,8 +1363,6 @@ void main(string command)
 					"up building up drippy juice in a brief aftercore stint that you don't want to " +
 					"drip in. Also note that if this is high enough to consider caviar, you will " +
 					"probably bump in to autoBuyPriceLimit.");
-				print("CONSUME.ALLOWLIFETIMELIMITED - If set to true, will act like ALLOWLIFETIMELIMITED" +
-					"was passed as an argument every time.");
 				return;
 			default:
 				print('Unknown command "' + commands[i] + '"', "red");

--- a/RELEASE/scripts/CONSUME/INFO.ash
+++ b/RELEASE/scripts/CONSUME/INFO.ash
@@ -38,13 +38,6 @@ boolean is_monday()
 	return numeric_modifier($item[tuesday's ruby], "muscle percent") == 5.0;
 }
 
-boolean allowLifetimeLimited = false;
-
-void allow_lifetime_limited()
-{
-	allowLifetimeLimited = true;
-}
-
 int daily_limit(item it)
 {
 	switch(it)
@@ -111,27 +104,6 @@ int daily_limit(item it)
 		// Universal Seasoning
 		case $item[Universal Seasoning]:
 			return item_amount($item[Universal Seasoning]) - get_property("_universalSeasoningsUsed").to_int();
-		case $item[Calzone of Legend]:
-			return (get_property("calzoneOfLegendEaten").to_boolean() || !allowLifetimeLimited) ? 0 : 1;
-		case $item[Deep Dish of Legend]:
-			return (get_property("deepDishOfLegendEaten").to_boolean() || !allowLifetimeLimited) ? 0 : 1;
-		case $item[Pizza of Legend]:
-			return (get_property("pizzaOfLegendEaten").to_boolean() || !allowLifetimeLimited) ? 0 : 1;
-		// rip
-		case $item[voodoo snuff]:
-			return get_property("_voodooSnuffUsed").to_boolean() ? 0 : 1;
-		case $item[Frosty's frosty mug]:
-			return get_property("_frostyMugUsed").to_boolean() ? 0 : 1;
-		case $item[jar of fermented pickle juice]:
-			return get_property("_pickleJuiceDrunk").to_boolean() ? 0 : 1;
-		case $item[Ol' Scratch's salad fork]:
-			return get_property("_saladForkUsed").to_boolean() ? 0 : 1;
-		case $item[extra-greasy slider]:
-			return get_property("_extraGreasySliderEaten").to_boolean() ? 0 : 1;
-		case $item[Hodgman's blanket]:
-			return get_property("_hodgmansBlanketDrunk").to_boolean() ? 0 : 1;
-		case $item[tin cup of mulligan stew]:
-			return get_property("_mulliganStewEaten").to_boolean() ? 0 : 1;
 		// TODO: MOOOOOOOOOOOOOORE
 		default: return -1;
 	}
@@ -139,10 +111,6 @@ int daily_limit(item it)
 
 int daily_limit(skill sk)
 {
-	if (!have_skill(sk))
-	{
-		return 0;
-	}
 	switch(sk)
 	{
 		case $skill[Sweat Out Some Booze]:
@@ -267,30 +235,23 @@ boolean has_unwanted_text_effect(item it)
 	return it.string_modifier("Effect").to_effect().is_unwanted_text_effect();
 }
 
-// defined in HELPERS.ash
-boolean care_about_ingredients(item it);
-
 boolean can_acquire(item it)
 {
-	if(it == $item[Jeppson's Malort]) {
-		return false;
-	}
-
-	if(it.tradeable.to_boolean()) {
+	if ($items[baked veggie ricotta casserole,
+	plain calzone,
+	roasted vegetable focaccia,
+	ratatouille de Jarlsberg,
+	Jarlsberg's vegetable soup,
+	roasted vegetable of Jarlsberg,
+	St. Pete's sneaky smoothie,
+	Pete's wiley whey bar,
+	Pete's rich ricotta,
+	Boris's beer,
+	honey bun of Boris,
+	Boris's bread] contains it) {
+		// these are all untradable Cookbookbat consumables which can be crafted from tradeable ingredients
 		return true;
 	}
-
-	if(!care_about_ingredients(it)) {
-		return false;
-	}
-
-	int [item] ingredients = get_ingredients(it);
-	boolean hasIngredients = false;
-	boolean canGetIngredients = true;
-	foreach ingredient, quantity in ingredients {
-		hasIngredients = true;
-		canGetIngredients = canGetIngredients && can_acquire(ingredient);
-	}
-
-	return hasIngredients && canGetIngredients;
+	// for everything, just return use the tradeable record as before.
+	return it.tradeable.to_boolean();
 }

--- a/RELEASE/scripts/CONSUME/INFO.ash
+++ b/RELEASE/scripts/CONSUME/INFO.ash
@@ -92,15 +92,23 @@ int daily_limit(item it)
 			return get_property("_drippyPilsnerUsed").to_boolean() ? 0 : 1;
 		// batfellow consumables
 		case $item[Kudzu salad]:
+			return get_property("_kudzuSaladEaten").to_boolean() ? 0 : 1;
 		case $item[Mansquito Serum]:
+			return get_property("_mansquitoSerumUsed").to_boolean() ? 0 : 1;
 		case $item[Miss Graves' vermouth]:
+			return get_property("_missGravesVermouthDrunk").to_boolean() ? 0 : 1;
 		case $item[The Plumber's mushroom stew]:
+			return get_property("_plumbersMushroomStewEaten").to_boolean() ? 0 : 1;
 		case $item[The Author's ink]:
+			return get_property("_authorsInkUsed").to_boolean() ? 0 : 1;
 		case $item[The Mad Liquor]:
+			return get_property("_madLiquorDrunk").to_boolean() ? 0 : 1;
 		case $item[Doc Clock's thyme cocktail]:
+			return get_property("_docClocksThymeCocktailDrunk").to_boolean() ? 0 : 1;
 		case $item[Mr. Burnsger]:
+			return get_property("_mrBurnsgerEaten").to_boolean() ? 0 : 1;
 		case $item[The Inquisitor's unidentifiable object]:
-			return 1;
+			return get_property("_inquisitorsUnidentifiableObjectUsed").to_boolean() ? 0 : 1;
 		// Universal Seasoning
 		case $item[Universal Seasoning]:
 			return item_amount($item[Universal Seasoning]) - get_property("_universalSeasoningsUsed").to_int();

--- a/RELEASE/scripts/CONSUME/INFO.ash
+++ b/RELEASE/scripts/CONSUME/INFO.ash
@@ -118,7 +118,7 @@ int daily_limit(skill sk)
 			return min(get_property("sweat").to_int()/25, 3 - get_property("_sweatOutSomeBoozeUsed").to_int());
 		case $skill[Aug. 16th: Roller Coaster Day!]:
 			// scepter skills can only be cast once a day but the skill of the day doesn't count towards our 5 uses per day.
-			return (get_property("_aug16Cast").to_boolean() || (get_property("_augSkillsCast").to_int() >= 5 && to_skill(7451 + format_date_time("yyyyMMdd", today_to_string(), "dd").to_int()) != sk)) ? 0 : 1;
+			return (available_amount($item[august scepter]) == 0 || get_property("_aug16Cast").to_boolean() || (get_property("_augSkillsCast").to_int() >= 5 && to_skill(7451 + format_date_time("yyyyMMdd", today_to_string(), "dd").to_int()) != sk)) ? 0 : 1;
 		default:
 			return -1;
 	}

--- a/RELEASE/scripts/CONSUME/INFO.ash
+++ b/RELEASE/scripts/CONSUME/INFO.ash
@@ -111,6 +111,10 @@ int daily_limit(item it)
 
 int daily_limit(skill sk)
 {
+	if (!have_skill(sk))
+	{
+		return 0;
+	}
 	switch(sk)
 	{
 		case $skill[Sweat Out Some Booze]:
@@ -118,7 +122,7 @@ int daily_limit(skill sk)
 			return min(get_property("sweat").to_int()/25, 3 - get_property("_sweatOutSomeBoozeUsed").to_int());
 		case $skill[Aug. 16th: Roller Coaster Day!]:
 			// scepter skills can only be cast once a day but the skill of the day doesn't count towards our 5 uses per day.
-			return (available_amount($item[august scepter]) == 0 || get_property("_aug16Cast").to_boolean() || (get_property("_augSkillsCast").to_int() >= 5 && to_skill(7451 + format_date_time("yyyyMMdd", today_to_string(), "dd").to_int()) != sk)) ? 0 : 1;
+			return (get_property("_aug16Cast").to_boolean() || (get_property("_augSkillsCast").to_int() >= 5 && to_skill(7451 + format_date_time("yyyyMMdd", today_to_string(), "dd").to_int()) != sk)) ? 0 : 1;
 		default:
 			return -1;
 	}


### PR DESCRIPTION
These were added to mafia at some point & @pstalcup hit an issue today where his personal Halloween farming script had already consumed one of these & CONSUME then failed when it tried to also consume one.