### PR TITLE
do not add lupine appetite hormones if the user is < lvl 15

### DIFF
--- a/RELEASE/scripts/CONSUME.ash
+++ b/RELEASE/scripts/CONSUME.ash
@@ -886,7 +886,6 @@ void handle_organ_expanders(Diet d, OrganSpace space, OrganSpace max, boolean ni
 
 	d.handle_stomache_expander(space, max, $item[cuppa Voraci tea], 1);
 	d.handle_stomache_expander(space, max, $item[sweet tooth], 1);
-	d.handle_stomache_expander(space, max, $item[lupine appetite hormones], 3);
 	d.handle_stomache_expander(space, max, $item[distention pill], 1);
 
 	if(nightcap && have_familiar($familiar[stooper]) && my_familiar() != $familiar[stooper])
@@ -896,6 +895,12 @@ void handle_organ_expanders(Diet d, OrganSpace space, OrganSpace max, boolean ni
 		d.add_action(useStooper);
 		space.inebriety += 1;
 		max.inebriety += 1;
+	}
+	if(my_level() < 15) {
+		return;
+	} else
+	{
+		d.handle_stomache_expander(space, max, $item[lupine appetite hormones], 3);
 	}
 }
 


### PR DESCRIPTION
simple ask based on short convo in ASS crimbo channel. lupine hormones require level 15 and it doesn't look like consume checks it right now