### PR TITLE
skip foods with u or no i's in the name in 11TIHAU

### DIFF
--- a/RELEASE/scripts/CONSUME.ash
+++ b/RELEASE/scripts/CONSUME.ash
@@ -284,6 +284,9 @@ void evaluate_consumables()
 		if((it.is_bloody() != (my_class() == $class[Vampyre])) && (c.organ == ORGAN_STOMACHE || c.organ == ORGAN_LIVER))
 			continue;
 
+		if (it.has_u() && my_path() == $path[11 Things I Hate About U] && c.organ == ORGAN_STOMACHE) // food with u's in the name can't be eaten in this path
+			continue;
+
 		float advs_per_space = c.it.get_adventures().average() / c.space;
 		float fites_per_space = c.it.get_fites().to_float() / c.space;
 		float drip_per_space = c.it.get_drippiness().to_float() / c.space;

--- a/RELEASE/scripts/CONSUME.ash
+++ b/RELEASE/scripts/CONSUME.ash
@@ -284,8 +284,8 @@ void evaluate_consumables()
 		if((it.is_bloody() != (my_class() == $class[Vampyre])) && (c.organ == ORGAN_STOMACHE || c.organ == ORGAN_LIVER))
 			continue;
 
-		if (it.has_u() && my_path() == $path[11 Things I Hate About U] && c.organ == ORGAN_STOMACHE) // food with u's in the name can't be eaten in this path
-			continue;
+		if (my_path() == $path[11 Things I Hate About U] && c.organ == ORGAN_STOMACHE && (it.has_u() || !it.has_i()))
+			continue; // cannot eat things which don't have i's in the name or have u's in the name in this path.
 
 		float advs_per_space = c.it.get_adventures().average() / c.space;
 		float fites_per_space = c.it.get_fites().to_float() / c.space;

--- a/RELEASE/scripts/CONSUME/INFO.ash
+++ b/RELEASE/scripts/CONSUME/INFO.ash
@@ -265,7 +265,12 @@ boolean is_bloody(item it)
 
 boolean has_u(item it)
 {
-	return it.name.contains_text("u");
+	return it.name.to_lower_case().contains_text("u");
+}
+
+boolean has_i(item it)
+{
+	return it.name.to_lower_case().contains_text("i");
 }
 
 boolean is_unwanted_text_effect(effect ef)

--- a/RELEASE/scripts/CONSUME/INFO.ash
+++ b/RELEASE/scripts/CONSUME/INFO.ash
@@ -263,6 +263,11 @@ boolean is_bloody(item it)
 	return it.notes.contains_text("Vampyre");
 }
 
+boolean has_u(item it)
+{
+	return it.name.contains_text("u");
+}
+
 boolean is_unwanted_text_effect(effect ef)
 {
 	return $effects[


### PR DESCRIPTION
For some reason mafia still sets the adventure gain on foods with U's and foods which lack I's in the name in 11TIHAU even though it doesn't list them in the Food tab of the Item Manager.

When trying to eat them manually, for foods with U's the game says "The Us in this have made it rotten." and they aren't consumed. For foods which lack I's the game says "There are not enough Is in this food to be worth eating." and they aren't consumed.

Without:
```
Your ideal diet: acquire 1 milk of magnesium; acquire 3 mojo filter; acquire 2 chocolate seal-clubbing club; acquire 1 essential tofu; acquire 1 synthetic dog hair pill; acquire 1 distention pill; acquire 8 antimatter wad; acquire 2 transdermal smoke patch; acquire 2 linguini immondizia bianco; acquire 19 Sacramento wine; acquire 2 mini kiwi aioli; acquire 2 mini kiwi digitized cookies; acquire 2 clock; closet put 43 Special Seasoning; checkpoint; cast 2 The Ode to Booze; use milk of magnesium; equip mafia pinky ring; use distention pill; drink Sacramento wine; chew 7 antimatter wad; chew transdermal smoke patch; use 2 mini kiwi aioli; eat 2 linguini immondizia bianco; eat mini kiwi digitized cookies; drink 16 Sacramento wine; use 3 mojo filter; use synthetic dog hair pill; use essential tofu; cast Sweat Out Some Booze; cast Aug. 16th: Roller Coaster Day!; chew antimatter wad; chew transdermal smoke patch; eat mini kiwi digitized cookies; drink 2 Sacramento wine; use 2 chocolate seal-clubbing club; use 2 clock; familiar Grey Goose; outfit checkpoint; closet take 43 Special Seasoning;
This should cost roughly 237,738 meat
Adventure yield should be roughly 337-376 (average 356.5)
```

With:
```
Your ideal diet: acquire 1 milk of magnesium; acquire 3 mojo filter; acquire 2 chocolate seal-clubbing club; acquire 1 essential tofu; acquire 1 synthetic dog hair pill; acquire 1 distention pill; acquire 8 antimatter wad; acquire 2 transdermal smoke patch; acquire 19 Sacramento wine; acquire 17 mini kiwi digitized cookies; acquire 2 clock; closet put 43 Special Seasoning; checkpoint; cast 2 The Ode to Booze; use milk of magnesium; equip mafia pinky ring; use distention pill; drink Sacramento wine; chew 7 antimatter wad; chew transdermal smoke patch; eat 16 mini kiwi digitized cookies; drink 16 Sacramento wine; use 3 mojo filter; use synthetic dog hair pill; use essential tofu; cast Sweat Out Some Booze; cast Aug. 16th: Roller Coaster Day!; chew antimatter wad; chew transdermal smoke patch; eat mini kiwi digitized cookies; drink 2 Sacramento wine; use 2 chocolate seal-clubbing club; use 2 clock; familiar Grey Goose; outfit checkpoint; closet take 43 Special Seasoning;
This should cost roughly 389,402 meat
Adventure yield should be roughly 395-434 (average 414.5)
```
note the only difference is the 3 linguini immondizia bianco's have been (correctly) replaced with 15 more mini kiwi digitized cookies.