### PR TITLE
Add Pork Elf toilet support to the diet

### DIFF
--- a/RELEASE/scripts/CONSUME.ash
+++ b/RELEASE/scripts/CONSUME.ash
@@ -14,6 +14,13 @@ int songDuration = my_accordion_buff_duration();
 boolean firstPassComplete = false;
 boolean consumablesEvaluated = false;
 
+boolean pork_elf_toilet_available()
+{
+	return (get_campground() contains $item[Pork Elf toilet])
+		&& !get_property("_porkElfToiletUsed").to_boolean()
+		&& total_free_rests() > get_property("timesRested").to_int();
+}
+
 int stomache_value(int space);
 int liver_value(int space);
 int spleen_value(int space);
@@ -940,6 +947,17 @@ Diet get_diet(OrganSpace space, OrganSpace max, boolean nightcap)
 
 	d.handle_organ_expanders(space, max, nightcap);
 
+	// Reserve an extra fullness slot for the Pork Elf toilet if available.
+	// The toilet procs on the first daily campground rest at >=2 fullness,
+	// reducing fullness by 1 and allowing one extra food item to be eaten.
+	boolean useToilet = pork_elf_toilet_available() && space.fullness >= 2;
+	int realFullnessLimit = max.fullness;
+	if(useToilet)
+	{
+		space.fullness += 1;
+		max.fullness += 1;
+	}
+
 	// do the shotglass drink first
 	if(item_amount($item[mime army shotglass]) > 0 &&
 		!get_property("_mimeArmyShotglassUsed").to_boolean())
@@ -994,6 +1012,33 @@ Diet get_diet(OrganSpace space, OrganSpace max, boolean nightcap)
 			sort booze by -value.get_value(d) / value.space;
 		}
 	}
+	// Insert a campground rest just before the food action that pushes past the
+	// real fullness cap, so the toilet flush makes room for that item.
+	// cumulative must be >=2 at that point to satisfy the toilet's requirement.
+	if(useToilet)
+	{
+		int cumulative = 0;
+		int insertAt = -1;
+		for(int i = 0; i < d.actions.count(); ++i)
+		{
+			if(d.actions[i].organ == ORGAN_STOMACHE)
+			{
+				if(cumulative >= 2 && cumulative + d.actions[i].space > realFullnessLimit)
+				{
+					insertAt = i;
+					break;
+				}
+				cumulative += d.actions[i].space;
+			}
+		}
+		if(insertAt >= 0)
+		{
+			DietAction restAction;
+			restAction.organ = ORGAN_REST;
+			d.insert_action(restAction, insertAt);
+		}
+	}
+
 	handle_chocolates(d);
 	handle_extra_time(d);
 	handle_clock(d);
@@ -1183,6 +1228,8 @@ void append_diet_action(buffer b, DietAction da, int amount, Diet d)
 		b.append("maximize hp,10cold res,10hot res; ");
 	else if(da.organ == ORGAN_CHECKPOINT)
 		b.append("checkpoint; ");
+	else if(da.organ == ORGAN_REST)
+		b.append("rest 1 campground; ");
 	else if(da.organ == ORGAN_RESTORE)
 	{
 		b.append("familiar ");

--- a/RELEASE/scripts/CONSUME/CONSTANTS.ash
+++ b/RELEASE/scripts/CONSUME/CONSTANTS.ash
@@ -10,6 +10,7 @@ int ORGAN_CHECKPOINT = 8; // checkpoint
 int ORGAN_RESTORE = 9; // familiar currfam; outfit checkpoint
 int ORGAN_SHRUG = 10;
 int ORGAN_AUTOMATIC = 11; // special seasoning and some others but they only impact substats so w/e
+int ORGAN_REST = 12; // campground rest, e.g. to proc the Pork Elf toilet
 int ORGAN_ERROR = 69420;
 
 int MAX_MEAT = 999999999999;


### PR DESCRIPTION
## Summary

The Pork Elf toilet reduces fullness by 1 on the first daily **campground** rest, provided at least 2 fullness is already used. CONSUME currently has no awareness of this — the free slot goes unused on days driven by CONSUME standalone.

This PR integrates the toilet into the diet plan:

- Plans one extra fullness slot when the toilet is available.
- Fills the stomach past the real cap (cap+1 total food).
- Injects a single `rest 1 campground;` just before the food action that would exceed the real cap, so the toilet flush makes room for that item.

### Guard conditions (`pork_elf_toilet_available()`)

- `Pork Elf toilet` is present in `get_campground()`.
- `_porkElfToiletUsed` is `false`.
- A free rest is available (`total_free_rests() > timesRested`), so the rest **never costs an adventure**.

The extra slot is only reserved when the remaining fullness to fill is >= 2 (i.e. the toilet would actually proc). If food runs out before the extra slot is needed, no rest is injected and the diet is simply <= cap — no harm done.

### Changes

- **`CONSUME/CONSTANTS.ash`**: add `ORGAN_REST = 12`.
- **`CONSUME.ash`**: add `pork_elf_toilet_available()` helper; reserve/inject logic in `get_diet()`; emit `rest 1 campground;` in `append_diet_action()`.

## Testing

`CONSUME SIM` with the toilet installed and `_porkElfToiletUsed=false` prints a diet planning `fullness_limit()+1` fullness with exactly one `rest 1 campground;` positioned among the food items, before the cap-exceeding item.

With `_porkElfToiletUsed=true` (or toilet absent, or no free rests remaining), `CONSUME SIM` plans the normal `fullness_limit()` with no rest in the diet.